### PR TITLE
Enable capabilities for sections

### DIFF
--- a/templates/enamel.c.jinja
+++ b/templates/enamel.c.jinja
@@ -109,9 +109,15 @@ static void prv_set_{{ item|getid|cvarname }}({{ item|getid|cvarname|upper }}Val
 
 {% for item in config -%}
 {% if item['type'] == 'section' %}
+{% if 'capabilities' in item %}
+#if {{ item['capabilities']|getdefines }}
+{% endif %}
 {% for item in item['items'] %}
 {{ item_accessors_code(item) }}
 {%- endfor %}
+{% if 'capabilities' in item %}
+#endif
+{% endif %}
 {% else %}
 {{ item_accessors_code(item) }}
 {%- endif %}

--- a/templates/enamel.h.jinja
+++ b/templates/enamel.h.jinja
@@ -56,9 +56,15 @@ int32_t enamel_get_{{ item|getid|cvarname }}();
 
 {% for item in config %}
 {% if item['type'] == 'section' %}
+{% if 'capabilities' in item %}
+#if {{ item['capabilities']|getdefines }}
+{% endif %}
 {% for item in item['items'] %}
 {{ item_header(item) }}
 {%- endfor %}
+{% if 'capabilities' in item %}
+#endif
+{% endif %}
 {% else %}
 {{ item_header(item) }}
 {%- endif %}


### PR DESCRIPTION
Clay supports the `capabilities` property on sections so you can exclude entire sections based on the connected watch's capabilities.

Bad things happen to Enamel if you use this functionality combined with duplicated messageKeys. It will declare the same static vars multiple times. 

This PR fixes the behavior 
