### PR TITLE
PubSub event handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ node_modules/
 *.pyc
 
 tests/include/pebble
-tests/include/linked-list
+tests/include/@smallstoneapps
 tests/generated/
 tests/linked-list.c

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CC_TEST=arm-none-eabi-gcc
 CFLAGS=-std=c11
 AR=arm-none-eabi-ar
 endif
-CINCLUDES=-I $(PEBBLE_HEADERS) -I tests/ -I tests/generated/ -I tests/include/ -I tests/include/linked-list
+CINCLUDES=-I $(PEBBLE_HEADERS) -I tests/ -I tests/generated/ -I tests/include/ -I tests/include/@smallstoneapps/linked-list
 
 TEST_FILES=tests/enamel.c
 SRC_FILES=tests/generated/enamel.c tests/linked-list.c

--- a/templates/enamel.c.jinja
+++ b/templates/enamel.c.jinja
@@ -3,6 +3,7 @@
  */
 
 #include <pebble.h>
+#include <@smallstoneapps/linked-list/linked-list.h>
 #include <pebble-events/pebble-events.h>
 #include "enamel.h"
 
@@ -13,8 +14,14 @@
 #define ENAMEL_PKEY 3000000000
 #define ENAMEL_DICT_PKEY (ENAMEL_PKEY+1)
 
+typedef struct {
+	EnamelSettingsReceivedHandler *handler;
+	void *context;
+} SettingsReceivedState;
+
+static LinkedRoot *s_handler_list;
+
 static EventHandle s_event_handle;
-static EnamelSettingsReceivedCallback *s_settings_received_callback; 
 
 static DictionaryIterator s_dict;
 static uint8_t* s_dict_buffer = NULL;
@@ -210,6 +217,12 @@ static uint32_t prv_map_messagekey(const uint32_t key){
 static void prv_key_update_cb(const uint32_t key, const Tuple *new_tuple, const Tuple *old_tuple, void *context){
 }
 
+static bool prv_each_settings_received(void *this, void *context) {
+	SettingsReceivedState *state=(SettingsReceivedState *)this;
+	state->handler(state->context);
+	return true;
+}
+
 static void prv_inbox_received_handle(DictionaryIterator *iter, void *context) {
 	if(dict_find(iter, {{ config|getFirstMessageKey}})){
 		if(s_dict_buffer){
@@ -229,8 +242,8 @@ static void prv_inbox_received_handle(DictionaryIterator *iter, void *context) {
 		dict_write_end(&s_dict);
 		dict_merge(&s_dict, &s_dict_size, iter, false, prv_key_update_cb, NULL);
 
-		if(s_settings_received_callback){
-			s_settings_received_callback();
+		if(s_handler_list){
+			linked_list_foreach(s_handler_list, prv_each_settings_received, NULL);
 		}
 
 		s_config_changed = true;
@@ -287,7 +300,6 @@ void enamel_init(){
 	dict_read_begin_from_buffer(&s_dict, s_dict_buffer, s_dict_size);
 	
 	s_config_changed = false;
-	s_settings_received_callback = NULL;
 	s_event_handle = events_app_message_register_inbox_received(prv_inbox_received_handle, NULL);
 	events_app_message_request_inbox_size(prv_get_inbound_size());
 }
@@ -305,10 +317,31 @@ void enamel_deinit(){
 
 	s_config_changed = false;
 	events_app_message_unsubscribe(s_event_handle);
-	s_settings_received_callback = NULL;
 }
 
-void enamel_register_settings_received(EnamelSettingsReceivedCallback *callback){
-	s_settings_received_callback = callback;
+EventHandle enamel_settings_received_subscribe(EnamelSettingsReceivedHandler *handler, void *context) {
+	if (!s_handler_list) {
+		s_handler_list = linked_list_create_root();
+	}
+
+	SettingsReceivedState *this = malloc(sizeof(SettingsReceivedState));
+	this->handler = handler;
+	this->context = context;
+	linked_list_append(s_handler_list, this);
+
+	return this;
 }
 
+void enamel_settings_received_unsubscribe(EventHandle handle) {
+	int16_t index = linked_list_find(s_handler_list, handle);
+	if (index == -1) {
+		return;
+	}
+
+	free(linked_list_get(s_handler_list, index));
+	linked_list_remove(s_handler_list, index);
+	if (linked_list_count(s_handler_list) == 0) {
+		free(s_handler_list);
+		s_handler_list = NULL;
+	}
+}

--- a/templates/enamel.h.jinja
+++ b/templates/enamel.h.jinja
@@ -78,8 +78,10 @@ void enamel_init();
 
 void enamel_deinit();
 
-typedef void(EnamelSettingsReceivedCallback)(void);
+typedef void* EventHandle;
+typedef void(EnamelSettingsReceivedHandler)(void* context);
 
-void enamel_register_settings_received(EnamelSettingsReceivedCallback *callback);
+EventHandle enamel_settings_received_subscribe(EnamelSettingsReceivedHandler *handler, void *context);
+void enamel_settings_received_unsubscribe(EventHandle handle);
 
 #endif

--- a/tests/pebble_stub.c
+++ b/tests/pebble_stub.c
@@ -1,5 +1,5 @@
 #include <pebble.h>
-#include <linked-list/linked-list.h>
+#include <@smallstoneapps/linked-list/linked-list.h>
 #include "constants.h"
 
 static LinkedRoot* s_persist_root = NULL;

--- a/tests/travis-install.sh
+++ b/tests/travis-install.sh
@@ -13,9 +13,9 @@ touch tests/include/pebble/pebble_warn_unsupported_functions.h
 rm $SDK_ZIP_NAME
 rm -r sdk-core
 
-mkdir -p tests/include/linked-list
+mkdir -p tests/include/@smallstoneapps/linked-list
 wget https://raw.githubusercontent.com/smallstoneapps/linked-list/master/include/linked-list.h
-mv linked-list.h tests/include/linked-list/linked-list.h
+mv linked-list.h tests/include/@smallstoneapps/linked-list/linked-list.h
 wget https://raw.githubusercontent.com/smallstoneapps/linked-list/master/src/c/linked-list.c
 mv linked-list.c tests/linked-list.c
 


### PR DESCRIPTION
Use a PubSub setup like pebble-events does to allow multiple components
to be notified when settings are received. This does require clients to
keep track of handles for unsubscribing, but if a client is already
using pebble-events then it should feel natural.
